### PR TITLE
Implementing use count

### DIFF
--- a/technical-documents/source-code/ecomon/backend/models.py
+++ b/technical-documents/source-code/ecomon/backend/models.py
@@ -98,6 +98,18 @@ class PlayerCards(models.Model):
         max_allowed = self.get_use_count()
 
         if self.use_count >= max_allowed:
+
+            #clears deck if card is deleted
+            profile = self.player.profile
+            if profile.deck_card_1 == self.card:
+                profile.deck_card_1 = None
+            if profile.deck_card_2 == self.card:
+                profile.deck_card_2 = None
+            if profile.deck_card_3 == self.card:
+                profile.deck_card_3 = None
+
+
+            profile.save()
             self.delete()
             return True
         return False

--- a/technical-documents/source-code/ecomon/backend/models.py
+++ b/technical-documents/source-code/ecomon/backend/models.py
@@ -103,10 +103,9 @@ class PlayerCards(models.Model):
         return False
     
     def increment_use(self):
-        """Increment use count and check if card should be deleted"""
+        """Increment use count"""
         self.use_count += 1
         self.save()
-        return self.check_and_delete()
 
 
 

--- a/technical-documents/source-code/ecomon/backend/models.py
+++ b/technical-documents/source-code/ecomon/backend/models.py
@@ -95,7 +95,7 @@ class PlayerCards(models.Model):
         Check if the card is to be removed
         '''
 
-        max_allowed = self.get_max_uses()
+        max_allowed = self.get_use_count()
 
         if self.use_count >= max_allowed:
             self.delete()

--- a/technical-documents/source-code/ecomon/backend/models.py
+++ b/technical-documents/source-code/ecomon/backend/models.py
@@ -68,6 +68,48 @@ class PlayerCards(models.Model):
     in_gym = models.BooleanField()
     use_count = models.IntegerField() # Depends on the card type, check if this record is removed
 
+    def get_use_count(self):
+        '''
+        Get the maximum number of uses for the card
+        '''
+        base_max_uses = {
+            1: 8, #Plastic cards
+            2: 5, #Recycling cards
+            3: 3 #Plant cards
+
+        }
+
+        player_team = self.player.profile.team_name.name.lower()
+        card_type = self.card.card_type
+
+        max_uses = base_max_uses[card_type]
+
+        if (player_team == 'reuse'): 
+            max_uses += 3
+
+        return max_uses
+
+
+    def check_and_remove(self):
+        '''
+        Check if the card is to be removed
+        '''
+
+        max_allowed = self.get_max_uses()
+
+        if self.use_count >= max_allowed:
+            self.delete()
+            return True
+        return False
+    
+    def increment_use(self):
+        """Increment use count and check if card should be deleted"""
+        self.use_count += 1
+        self.save()
+        return self.check_and_delete()
+
+
+
 class Achievement(models.Model):
     '''
     Achievement database model

--- a/technical-documents/source-code/ecomon/backend/views.py
+++ b/technical-documents/source-code/ecomon/backend/views.py
@@ -243,6 +243,14 @@ def completed_gym_battle(request):
     did_win = request.GET.get('did_win')
     gym_id = request.GET.get('gym_id')
 
+    #get players deck
+    player_deck_cards = get_player_deck(request.user)
+    
+    # Increment use count for each card used in battle
+    for card in player_deck_cards:
+        player_card = PlayerCards.objects.get(player=request.user, card=card)
+        player_card.increment_use()
+
     # Ensure the required parameters are present
     if not did_win or not gym_id:
         return redirect('missing-battle-condition')
@@ -293,6 +301,16 @@ def completed_gym_battle(request):
             update_cooldown(gym)
             # Add a pack to the user's profile
             add_players_pack(request.user)
+
+        
+        for card in player_deck_cards:
+            player_card = PlayerCards.objects.get(player=request.user, card=card)
+            player_card.increment_use()
+
+        players_cards = PlayerCards.objects.filter(player=request.user)
+        # Check and remove cards that have reached max uses
+        for player_card in players_cards:
+            player_card.check_and_remove()
 
         return render(request, 'backend/battles/gym-battle-completed.html', context)
 

--- a/technical-documents/source-code/ecomon/backend/views.py
+++ b/technical-documents/source-code/ecomon/backend/views.py
@@ -302,11 +302,12 @@ def completed_gym_battle(request):
             # Add a pack to the user's profile
             add_players_pack(request.user)
 
-        
+        # Increment use count for each card used in the battle
         for card in player_deck_cards:
             player_card = PlayerCards.objects.get(player=request.user, card=card)
             player_card.increment_use()
 
+        # Get the players cards and filter out the cards that have reached max uses
         players_cards = PlayerCards.objects.filter(player=request.user)
         # Check and remove cards that have reached max uses
         for player_card in players_cards:


### PR DESCRIPTION
-Functions for increasing use count and deleting packCards are now in the packCards model.
-Each type of card has a constant amount in packCard that has +3 when the team is reuse
- After each battle in the view the use count function is called on all 3 cards in the deck, if win the cards will be put in the gym deck first, then the card is deleted from playerCards + image removed from their deck to not game the system as it is stored in the user as an image rather than card.