### PR TITLE
Team benefits battle implementation

### DIFF
--- a/technical-documents/source-code/ecomon/backend/gym_service.py
+++ b/technical-documents/source-code/ecomon/backend/gym_service.py
@@ -92,5 +92,4 @@ def increase_win_count(user:User):
     profile = Profile.objects.get(user=user)
     profile.battles_won += 1
     profile.save()
-
-
+    

--- a/technical-documents/source-code/ecomon/backend/views.py
+++ b/technical-documents/source-code/ecomon/backend/views.py
@@ -233,7 +233,42 @@ def render_gym_battle(request, gym_id):
         player_deck_card1 = profile.deck_card_1 if profile and profile.deck_card_1 else None
         player_deck_card2 = profile.deck_card_2 if profile and profile.deck_card_2 else None
         player_deck_card3 = profile.deck_card_3 if profile and profile.deck_card_3 else None
+
+        # Retrieve Player's and Gym Owning teams
+        user_team = profile.team_name.name if profile else "No team"
+        gym_team = gym.owning_player.profile.team_name.name if gym.owning_player else "No team"
         
+        # Apply battle benefits based on the user's team
+        if user_team == "Recycle":
+            if player_deck_card1 and player_deck_card1.card_type == 2:
+                player_deck_card1.ability_power_1 += 10
+                if player_deck_card1.ability_power_2 != 0:
+                    player_deck_card1.ability_power_2 += 10
+            if player_deck_card2 and player_deck_card2.card_type == 2:
+                player_deck_card2.ability_power_1 += 10
+                if player_deck_card2.ability_power_2 != 0:
+                    player_deck_card2.ability_power_2 += 10
+            if player_deck_card3 and player_deck_card3.card_type == 2:
+                player_deck_card3.ability_power_1 += 10
+                if player_deck_card3.ability_power_2 != 0:
+                    player_deck_card3.ability_power_2 += 10
+        
+        # Apply battle benefits based on the gym's team
+        if gym_team == "Recycle":
+            if gym.card1.card_type == 2:
+                gym.card1.ability_power_1 += 10
+                if gym.card1.ability_power_2 != 0:
+                    gym.card1.ability_power_2 += 10
+            if gym.card2.card_type == 2:
+                gym.card2.ability_power_1 += 10
+                if gym.card2.ability_power_2 != 0:
+                    gym.card2.ability_power_2 += 10
+            if gym.card3.card_type == 2:
+                gym.card3.ability_power_1 += 10
+                if gym.card3.ability_power_2 != 0:
+                    gym.card3.ability_power_2 += 10
+            
+
         # Context variables to pass to the template
         context = {
             "gym_id": gym_id,
@@ -244,7 +279,9 @@ def render_gym_battle(request, gym_id):
             "gym_owning_player": gym.owning_player,
             "player_deck_card1": json.dumps(player_deck_card1.to_json()),
             "player_deck_card2": json.dumps(player_deck_card2.to_json()),
-            "player_deck_card3": json.dumps(player_deck_card3.to_json())
+            "player_deck_card3": json.dumps(player_deck_card3.to_json()),
+            "user_team": user_team,
+            "gym_team": gym_team,
         }
 
     except Gym.DoesNotExist:

--- a/technical-documents/source-code/ecomon/backend/views.py
+++ b/technical-documents/source-code/ecomon/backend/views.py
@@ -252,6 +252,16 @@ def render_gym_battle(request, gym_id):
                 player_deck_card3.ability_power_1 += 10
                 if player_deck_card3.ability_power_2 != 0:
                     player_deck_card3.ability_power_2 += 10
+        elif user_team == "Reduce":
+            gym.card1.ability_power_1 -= 5
+            gym.card2.ability_power_1 -= 5
+            gym.card3.ability_power_1 -= 5
+            if gym.card1.ability_power_2 != 0:
+                gym.card1.ability_power_2 -= 5
+            if gym.card2.ability_power_2 != 0:
+                gym.card2.ability_power_2 -= 5
+            if gym.card3.ability_power_2 != 0:
+                gym.card3.ability_power_2 -= 5
         
         # Apply battle benefits based on the gym's team
         if gym_team == "Recycle":
@@ -267,6 +277,17 @@ def render_gym_battle(request, gym_id):
                 gym.card3.ability_power_1 += 10
                 if gym.card3.ability_power_2 != 0:
                     gym.card3.ability_power_2 += 10
+        elif gym_team == "Reduce":
+            if player_deck_card1 and player_deck_card2 and player_deck_card3:
+                player_deck_card1.ability_power_1 -= 5
+                player_deck_card2.ability_power_1 -= 5
+                player_deck_card3.ability_power_1 -= 5
+                if player_deck_card1.ability_power_2 != 0:
+                    player_deck_card1.ability_power_2 -= 5
+                if player_deck_card2.ability_power_2 != 0:
+                    player_deck_card2.ability_power_2 -= 5
+                if player_deck_card3.ability_power_2 != 0:
+                    player_deck_card3.ability_power_2 -= 5
             
 
         # Context variables to pass to the template

--- a/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
+++ b/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', function () {
     setOpponentCardSlot2(opponentCardSlot2);
 });
 
+// Initialize variables to keep track of the player's and opponent's cards health points
 let maxPlayerHealth;
 let maxOpponentHealth;
 
@@ -145,14 +146,6 @@ function performCoinFlip() {
 
 // Function to start the game after the coin flip
 function startGame() {
-    // Initialize the start variables and rendering the cards
-    setPlayerActiveCard(activePlayerCard);
-    setPlayerCardSlot1(playerCardSlot1);
-    setPlayerCardSlot2(playerCardSlot2);
-    setOpponentActiveCard(activeOpponentCard);
-    setOpponentCardSlot1(opponentCardSlot1);
-    setOpponentCardSlot2(opponentCardSlot2);
-
     // Initialize battle log
     let battleLog = document.querySelector('.battle-log');
     battleLog.innerHTML += `<p>Coin flip result: ${isPlayerTurn ? username : opponent} goes first!</p>`;

--- a/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
+++ b/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
@@ -1,5 +1,5 @@
 // Wait for the DOM to be fully loaded before executing the code
-// TODO: Commenting new features
+// TODO: Commenting all new features
 document.addEventListener('DOMContentLoaded', function () {
     // Create and show the coin flip overlay
     createCoinFlipOverlay();

--- a/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
+++ b/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
@@ -54,6 +54,7 @@ function createCoinFlipOverlay() {
     coinContainer.style.height = '150px';
     coinContainer.style.position = 'relative';
     coinContainer.style.perspective = '1000px';
+    coinContainer.style.marginBottom = '30px'; // Add margin below coin
 
     // Create the coin
     const coin = document.createElement('div');
@@ -99,12 +100,89 @@ function createCoinFlipOverlay() {
     tails.style.color = 'white';
     tails.textContent = opponent;
 
+    // Create team info container
+    const teamInfoContainer = document.createElement('div');
+    teamInfoContainer.id = 'team-info-container';
+    teamInfoContainer.style.display = 'flex';
+    teamInfoContainer.style.justifyContent = 'space-between';
+    teamInfoContainer.style.width = '80%';
+    teamInfoContainer.style.maxWidth = '800px';
+    teamInfoContainer.style.color = 'white';
+    teamInfoContainer.style.fontFamily = 'Arial, sans-serif';
+
+    // Create user team info
+    const userTeamInfo = document.createElement('div');
+    userTeamInfo.className = 'team-info';
+    userTeamInfo.style.padding = '15px';
+    userTeamInfo.style.backgroundColor = 'rgba(132, 196, 76, 0.3)';
+    userTeamInfo.style.borderRadius = '8px';
+    userTeamInfo.style.width = '45%';
+    userTeamInfo.style.textAlign = 'center';
+
+    const userTeamTitle = document.createElement('h3');
+    userTeamTitle.textContent = username + "'s Team";
+    userTeamTitle.style.color = '#84C44C';
+    userTeamTitle.style.marginTop = '0';
+    userTeamTitle.style.marginBottom = '10px';
+
+    const userTeamBenefits = document.createElement('p');
+    if (userTeam === "Recycle") {
+        userTeamBenefits.textContent = 'Recycle Team Benefits: Recycle cards deal +10 damage on all moves';
+        userTeamBenefits.style.margin = '0';
+    } else if (userTeam === "Reduce") {
+        userTeamBenefits.textContent = 'Reduce Team Benefits: Player takes -5 damage from all moves';
+        userTeamBenefits.style.margin = '0';
+    } else if (userTeam === "Reuse") {
+        userTeamBenefits.textContent = 'Reuse Team Benefits: Players cards have increased use count';
+        userTeamBenefits.style.margin = '0';
+    }
+    userTeamInfo.appendChild(userTeamTitle);
+    userTeamInfo.appendChild(userTeamBenefits);
+
+    // Create opponent team info
+    const opponentTeamInfo = document.createElement('div');
+    opponentTeamInfo.className = 'team-info';
+    opponentTeamInfo.style.padding = '15px';
+    opponentTeamInfo.style.backgroundColor = 'rgba(255, 0, 0, 0.3)';
+    opponentTeamInfo.style.borderRadius = '8px';
+    opponentTeamInfo.style.width = '45%';
+    opponentTeamInfo.style.textAlign = 'center';
+
+    const opponentTeamTitle = document.createElement('h3');
+    opponentTeamTitle.textContent = opponent + "'s Team";
+    opponentTeamTitle.style.color = '#FF0000';
+    opponentTeamTitle.style.marginTop = '0';
+    opponentTeamTitle.style.marginBottom = '10px';
+
+    const opponentTeamBenefits = document.createElement('p');
+    if (opponentTeam === "Recycle") {
+        opponentTeamBenefits.textContent = 'Recycle Team Benefits: Recycle cards deal +10 damage on all moves';
+    } else if (opponentTeam === "Reduce") {
+        opponentTeamBenefits.textContent = 'Reduce Team Benefits: Opponent takes -5 damage from all moves';
+    } else if (opponentTeam === "Reuse") {
+        opponentTeamBenefits.textContent = 'Reuse Team Benefits: Opponents cards have increased use count';  
+    } else {
+        opponentTeamBenefits.textContent = 'Fossil Fuel Team Benefits: No team benefits';
+    }
+    opponentTeamBenefits.style.margin = '0';
+    opponentTeamInfo.appendChild(opponentTeamTitle);
+    opponentTeamInfo.appendChild(opponentTeamBenefits);
+
+    // Add team info to container
+    teamInfoContainer.appendChild(userTeamInfo);
+    teamInfoContainer.appendChild(opponentTeamInfo);
+
+    // Initially hide team info
+    teamInfoContainer.style.opacity = '0';
+    teamInfoContainer.style.transition = 'opacity 0.5s ease';
+
     // Assemble the elements
     coin.appendChild(heads);
     coin.appendChild(tails);
     coinContainer.appendChild(coin);
     overlay.appendChild(text);
     overlay.appendChild(coinContainer);
+    overlay.appendChild(teamInfoContainer);
     document.body.appendChild(overlay);
 }
 
@@ -112,6 +190,7 @@ function performCoinFlip() {
     const coin = document.getElementById('coin');
     const text = document.getElementById('coin-flip-text');
     const overlay = document.getElementById('coin-flip-overlay');
+    const teamInfo = document.getElementById('team-info-container');
 
     // Ensure coin starts at 0 rotation
     coin.style.transform = "rotateY(0deg)";
@@ -131,15 +210,20 @@ function performCoinFlip() {
             text.textContent = isHeads ? `${username} goes first!` : `${opponent} goes first!`;
             isPlayerTurn = isHeads;
 
+            // Show team information
+            teamInfo.style.opacity = '1';
+
+            // Increased delay before game starts (4 seconds instead of 1.5)
             setTimeout(() => {
                 overlay.style.opacity = '0';
-                overlay.style.transition = 'opacity 0.5s ease';
+                overlay.style.transition = 'opacity 0.8s ease';
 
+                // Increased delay for fade out (1 second instead of 0.5)
                 setTimeout(() => {
                     document.body.removeChild(overlay);
                     startGame();
-                }, 500);
-            }, 1500);
+                }, 1000);
+            }, 4000);
         }, 1000);
     }, 50); // Tiny delay to trigger reflow
 }

--- a/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
+++ b/technical-documents/source-code/ecomon/static/js/backend/battles/gymBattle.js
@@ -414,7 +414,6 @@ function handleOpponentTurn() {
     // Initialize battle log and choose a random move for the opponent
     let battleLog = document.querySelector('.battle-log');
     const moveChoice = Math.random() < 0.5 ? 1 : 2;
-
     // If the opponent randomly chooses the first move
     if (moveChoice === 1) {
         let result = activePlayerCard.health_points - activeOpponentCard.ability_power_1;

--- a/technical-documents/source-code/ecomon/templates/backend/battles/gym_battle.html
+++ b/technical-documents/source-code/ecomon/templates/backend/battles/gym_battle.html
@@ -15,7 +15,9 @@
         let opponentCardSlot1 = JSON.parse('{{ gym_card2 | safe }}');
         let opponentCardSlot2 = JSON.parse('{{ gym_card3 | safe }}');
         let username = '{{ username }}';
+        let userTeam = '{{ user_team }}';
         let opponent = '{{ gym_owning_player }}';
+        let opponentTeam = '{{ gym_team }}';
         let gymID = '{{ gym_id }}';
     </script>
     <!-- JavaScript Using the Variables -->


### PR DESCRIPTION
Implemented team benefits:
If a player belongs to team Recycle, all recycle cards deal +10 damage for all moves.
If a player belongs to team Reduce, on all turns the player takes -5 damage from all moves.

Implemented team benefits information div on the coin flip overlay.
This allows the user to know what benefits have been applied to both players.