### PR TITLE
resets gym owners cards to their collection if the gym is taken over

### DIFF
--- a/technical-documents/source-code/ecomon/backend/gym_service.py
+++ b/technical-documents/source-code/ecomon/backend/gym_service.py
@@ -93,3 +93,11 @@ def increase_win_count(user:User):
     profile.battles_won += 1
     profile.save()
     
+def reset_gym_player_cards(gym:Gym):
+    '''Resets the player's cards back to the user if the gym they were in is taken over by another player'''
+    user = gym.owning_player
+    cards_in_gym = [gym.card1,gym.card2,gym.card3]
+    for card in cards_in_gym:
+        player_card = PlayerCards.objects.get(player=user,card=card)
+        player_card.in_gym = False
+        player_card.save()

--- a/technical-documents/source-code/ecomon/backend/views.py
+++ b/technical-documents/source-code/ecomon/backend/views.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from accounts.player_service import get_player_deck, has_deck, add_players_pack
 from accounts.models import Profile
 from .pack_service import get_pack_count, reduce_user_pack_count,generate_pack, add_player_cards, increase_packs_opened
-from .gym_service import reset_profile_wrappers, update_gym_cards, update_owning_player, update_cooldown, increase_win_count, increase_bins_emptied
+from .gym_service import reset_profile_wrappers, update_gym_cards, update_owning_player, update_cooldown, increase_win_count, increase_bins_emptied, reset_gym_player_cards
 from .bin_service import is_bin_full, increment_wrapper_count
 from .models import Gym, Card, PlayerCards,Team
 from .achievement_service import check_and_award_achievements
@@ -387,6 +387,8 @@ def completed_gym_battle(request):
                 increase_win_count(request.user)
                 check_and_award_achievements(request.user, 'BATTLES')
                 player_collection_cards = get_player_deck(request.user)
+                # Reset the gym player's cards from in use to not in use before updating the gym's cards
+                reset_gym_player_cards(gym)
                 # Set the gym's cards & update the player's cards in use
                 update_gym_cards(request.user,player_collection_cards, gym)
                 # Clear the cards used by the player in the battle from their deck


### PR DESCRIPTION
- Added feature where if a gym owning player (e.g. called Solomon) had his gym taken over, the cards defending the gym return back to his collection to use (in_gym = false)